### PR TITLE
feat: code samples visual improvement

### DIFF
--- a/dev/css/main.css
+++ b/dev/css/main.css
@@ -7,16 +7,17 @@ body {
   gap: 10px;
 }
 
-#draggable {
+#draggable, .draggable {
   flex-basis: 50%;
   margin: 20px 0 0;
 }
 
-#draggable li:last-child {
+#draggable li:last-child,
+.draggable li:last-child {
   margin-bottom: 0;
 }
 
-#result-wrap {
+.result-wrap {
   flex-basis: 50%;
   margin: 20px 0 0;
   border: 1px solid #ccc;

--- a/dev/css/main.css
+++ b/dev/css/main.css
@@ -2,6 +2,27 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
+.sample-wrap {
+  display: flex;
+  gap: 10px;
+}
+
+#draggable {
+  flex-basis: 50%;
+  margin: 20px 0 0;
+}
+
+#draggable li:last-child {
+  margin-bottom: 0;
+}
+
+#result-wrap {
+  flex-basis: 50%;
+  margin: 20px 0 0;
+  border: 1px solid #ccc;
+  padding: 10px;
+}
+
 .nested-sort {
   padding: 0;
 }

--- a/dev/css/main.css
+++ b/dev/css/main.css
@@ -5,11 +5,13 @@ body {
 .sample-wrap {
   display: flex;
   gap: 10px;
+  margin: 20px 0;
 }
 
-#draggable, .draggable {
+#draggable,
+.draggable {
   flex-basis: 50%;
-  margin: 20px 0 0;
+  margin: 0;
 }
 
 #draggable li:last-child,
@@ -19,13 +21,14 @@ body {
 
 .result-wrap {
   flex-basis: 50%;
-  margin: 20px 0 0;
+  margin: 0;
   border: 1px solid #ccc;
   padding: 10px;
 }
 
 .nested-sort {
   padding: 0;
+  margin: 0;
 }
 
 .nested-sort--enabled li {

--- a/dev/data-driven-list.html
+++ b/dev/data-driven-list.html
@@ -15,7 +15,10 @@
 
   <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse. Touch screens are not supported yet! 😐</p>
 
-  <div id="draggable2"></div>
+  <div class="sample-wrap">
+    <div id="draggable"></div>
+    <pre class="result-wrap"></pre>
+  </div>
 </div>
 
 <!-- Scripts -->
@@ -46,11 +49,13 @@
     new NestedSort({
       actions: {
         onDrop: function (data) {
+          const resultWrap = document.querySelector('.result-wrap')
+          resultWrap.innerHTML = JSON.stringify(data, null, '  ')
           console.log(data)
         }
       },
       data: data,
-      el: '#draggable2',
+      el: '#draggable',
       droppingEdge: 5
     })
   })()

--- a/dev/data-persistence-in-local-storage.html
+++ b/dev/data-persistence-in-local-storage.html
@@ -16,7 +16,10 @@
   <p>Try to re-order the item and refresh the page. You'll see that your new order is persisting unless you clear your
     browser local storage.</p>
 
-  <div id="draggable"></div>
+  <div class="sample-wrap">
+    <div id="draggable"></div>
+    <pre class="result-wrap"></pre>
+  </div>
 </div>
 
 <!-- Scripts -->
@@ -33,6 +36,8 @@
     const dataKey = 'nestedSortData'
     const data = JSON.parse(localStorage.getItem(dataKey)) || originalData
     function onDrop (data) {
+      const resultWrap = document.querySelector('.result-wrap')
+      resultWrap.innerHTML = JSON.stringify(data, null, '  ')
       console.log(data)
       const newData = originalData.map(origItem => {
         const newItem = data.find(item => parseInt(item.item_id) === origItem.item_id)

--- a/dev/data-persistence-in-local-storage.html
+++ b/dev/data-persistence-in-local-storage.html
@@ -33,7 +33,7 @@
       { item_id: 4, item_title: 'Four', position: 2 },
       { item_id: 5, item_title: 'Five', position: 1 },
     ]
-    const dataKey = 'nestedSortData'
+    const dataKey = 'nestedSortDataDataPersistenceSample'
     const data = JSON.parse(localStorage.getItem(dataKey)) || originalData
     function onDrop (data) {
       const resultWrap = document.querySelector('.result-wrap')

--- a/dev/enable-disable.html
+++ b/dev/enable-disable.html
@@ -18,41 +18,79 @@
   <button type="button" onclick="initServerRenderedList()">Init / Enable</button>
   <button type="button" onclick="destroyServerRenderedList()">Destroy / Disable</button>
 
-  <ul id="server-rendered">
-    <li data-id="1">Topic 1</li>
-    <li data-id="2">Topic 2</li>
-    <li data-id="3">Topic 3
-      <ul data-id="3">
-        <li data-id="31">Topic 3-1</li>
-        <li data-id="32">Topic 3-2</li>
-      </ul>
-    </li>
-    <li data-id="4">Topic 4</li>
-    <li data-id="5">Topic 5</li>
-  </ul>
-
-  <hr>
+  <div class="sample-wrap">
+    <ul class="draggable">
+      <li data-id="1">Topic 1</li>
+      <li data-id="2">Topic 2</li>
+      <li data-id="3">Topic 3
+        <ul data-id="3">
+          <li data-id="31">Topic 3-1</li>
+          <li data-id="32">Topic 3-2</li>
+        </ul>
+      </li>
+      <li data-id="4">Topic 4</li>
+      <li data-id="5">Topic 5</li>
+    </ul>
+    <pre class="result-wrap result-wrap-1"></pre>
+  </div>
 
   <h2>Local storage persistent data-driven list</h2>
   <button type="button" onclick="initDataDrivenList()">Init / Enable</button>
   <button type="button" onclick="destroyDataDrivenList()">Destroy / Disable</button>
 
-  <div id="data-driven"></div>
+  <div class="sample-wrap">
+    <div id="draggable"></div>
+    <pre class="result-wrap result-wrap-2"></pre>
+  </div>
 </div>
 
 <!-- Scripts -->
 <script src="../dist/nested-sort.umd.js"></script>
 <script>
+  // Local storage persistent data-driven list
+  const originalData = [
+    { item_id: 1, item_title: 'One', position: 5 },
+    { item_id: 2, item_title: 'Two', position: 4 },
+    { item_id: 3, item_title: 'Three', position: 3 },
+    { item_id: 4, item_title: 'Four', position: 2 },
+    { item_id: 5, item_title: 'Five', position: 1 },
+  ]
+  const dataKey = 'nestedSortDataEnableDisableSample'
+  let data = JSON.parse(localStorage.getItem(dataKey)) || originalData
+
+  function onDropHandler (orderedItems) {
+    console.log(orderedItems)
+    const newData = originalData.map(origItem => {
+      const newItem = orderedItems.find(item => parseInt(item.item_id) === origItem.item_id)
+      return Object.assign({}, origItem, {
+        position: newItem.position,
+        item_parent: newItem.item_parent
+      })
+    })
+    data = newData
+    localStorage.setItem(dataKey, JSON.stringify(newData))
+  }
+
+  const propertyMap = {
+    id: 'item_id',
+    parent: 'item_parent',
+    text: 'item_title',
+    order: 'position',
+  }
+
   // Server rendered list
   const startServerRenderedList = () => {
     window.serverRenderedList = new NestedSort({
       actions: {
-        onDrop: function (data) {
-          console.log(data)
+        onDrop(data) {
+          const resultWrap = document.querySelector('.result-wrap-1')
+          resultWrap.innerHTML = JSON.stringify(data, null, '  ')
+          onDropHandler(data)
         }
       },
+      propertyMap,
       init: false,
-      el: '#server-rendered',
+      el: '.draggable',
       droppingEdge: 5
     })
   }
@@ -69,43 +107,19 @@
 
   startServerRenderedList()
 
-  // Local storage persistent data-driven list
-  const originalData = [
-    { item_id: 1, item_title: 'One', position: 5 },
-    { item_id: 2, item_title: 'Two', position: 4 },
-    { item_id: 3, item_title: 'Three', position: 3 },
-    { item_id: 4, item_title: 'Four', position: 2 },
-    { item_id: 5, item_title: 'Five', position: 1 },
-  ]
-  const dataKey = 'nestedSortData'
-  let data = JSON.parse(localStorage.getItem(dataKey)) || originalData
-  function onDrop (orderedItems) {
-    console.log(orderedItems)
-    const newData = originalData.map(origItem => {
-      const newItem = orderedItems.find(item => parseInt(item.item_id) === origItem.item_id)
-      return Object.assign({}, origItem, {
-        position: newItem.position,
-        item_parent: newItem.item_parent
-      })
-    })
-    data = newData
-    localStorage.setItem(dataKey, JSON.stringify(newData))
-  }
-
   const startDataDrivenList = () => {
     window.dataDrivenList = new NestedSort({
       actions: {
-        onDrop
+        onDrop(data) {
+          const resultWrap = document.querySelector('.result-wrap-2')
+          resultWrap.innerHTML = JSON.stringify(data, null, '  ')
+          onDropHandler(data)
+        }
       },
-      data: data,
+      data,
       init: false,
-      propertyMap: {
-        id: 'item_id',
-        parent: 'item_parent',
-        text: 'item_title',
-        order: 'position',
-      },
-      el: '#data-driven',
+      propertyMap,
+      el: '#draggable',
       droppingEdge: 5
     })
   }

--- a/dev/mapped-data-driven-list.html
+++ b/dev/mapped-data-driven-list.html
@@ -15,7 +15,10 @@
 
   <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse. Touch screens are not supported yet! 😐</p>
 
-  <div id="draggable"></div>
+  <div class="sample-wrap">
+    <div id="draggable"></div>
+    <pre class="result-wrap"></pre>
+  </div>
 </div>
 
 <!-- Scripts -->
@@ -37,6 +40,8 @@
     new NestedSort({
       actions: {
         onDrop: function (data) {
+          const resultWrap = document.querySelector('.result-wrap')
+          resultWrap.innerHTML = JSON.stringify(data, null, '  ')
           console.log(data)
         }
       },

--- a/dev/nesting-levels.html
+++ b/dev/nesting-levels.html
@@ -16,18 +16,21 @@
   <label for="nesting-level">Nesting Levels:</label>
   <input type="number" id="nesting-level" onchange="updateNestingLevels()" value="-1">
 
-  <ul id="draggable">
-    <li data-id="1">Topic 1</li>
-    <li data-id="2">Topic 2</li>
-    <li data-id="3">Topic 3</li>
-    <li data-id="4">Topic 4</li>
-    <li data-id="5">Topic 5</li>
-    <li data-id="6">Topic 6</li>
-    <li data-id="7">Topic 7</li>
-    <li data-id="8">Topic 8</li>
-    <li data-id="9">Topic 9</li>
-    <li data-id="10">Topic 10</li>
-  </ul>
+  <div class="sample-wrap">
+    <ul id="draggable">
+      <li data-id="1">Topic 1</li>
+      <li data-id="2">Topic 2</li>
+      <li data-id="3">Topic 3</li>
+      <li data-id="4">Topic 4</li>
+      <li data-id="5">Topic 5</li>
+      <li data-id="6">Topic 6</li>
+      <li data-id="7">Topic 7</li>
+      <li data-id="8">Topic 8</li>
+      <li data-id="9">Topic 9</li>
+      <li data-id="10">Topic 10</li>
+    </ul>
+    <pre class="result-wrap"></pre>
+  </div>
 </div>
 
 <!-- Scripts -->
@@ -38,6 +41,8 @@
     window.ns = new NestedSort({
       actions: {
         onDrop: function (data) {
+          const resultWrap = document.querySelector('.result-wrap')
+          resultWrap.innerHTML = JSON.stringify(data, null, '  ')
           console.log(data)
         }
       },

--- a/dev/ordered-data-driven-list.html
+++ b/dev/ordered-data-driven-list.html
@@ -15,7 +15,10 @@
 
   <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse. Touch screens are not supported yet! 😐</p>
 
-  <div id="draggable"></div>
+  <div class="sample-wrap">
+    <div id="draggable"></div>
+    <pre class="result-wrap"></pre>
+  </div>
 </div>
 
 <!-- Scripts -->
@@ -38,6 +41,8 @@
     new NestedSort({
       actions: {
         onDrop: function (data) {
+          const resultWrap = document.querySelector('.result-wrap')
+          resultWrap.innerHTML = JSON.stringify(data, null, '  ')
           console.log(data)
         }
       },

--- a/dev/server-rendered-list.html
+++ b/dev/server-rendered-list.html
@@ -13,27 +13,34 @@
 <div class="container">
   <h1>A server-rendered list</h1>
 
-  <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse. Touch screens are not supported yet! 😐</p>
+  <p>
+    The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse.
+    The result would appear on the right side of the screen.
+  </p>
 
   <input type="checkbox" id="property-mapping" onchange="updateList()">
   <label for="property-mapping">Use property mapping (affects the list data structure logged to the console after each drag and drop)</label>
 
-  <ul id="draggable">
-    <li data-id="1">Topic 1</li>
-    <li data-id="2">Topic 2</li>
-    <li data-id="3">Topic 3
-      <ul data-id="3">
-        <li data-id="31">Topic 3-1</li>
-        <li data-id="32">Topic 3-2</li>
-        <li data-id="33">Topic 3-3</li>
-      </ul>
-    </li>
-    <li data-id="4">Topic 4</li>
-    <li data-id="5">Topic 5</li>
-    <li data-id="6">Topic 6</li>
-    <li data-id="7">Topic 7</li>
-    <li data-id="8">Topic 8</li>
-  </ul>
+  <div class="sample-wrap">
+    <ul id="draggable">
+      <li data-id="1">Topic 1</li>
+      <li data-id="2">Topic 2</li>
+      <li data-id="3">Topic 3
+        <ul data-id="3">
+          <li data-id="31">Topic 3-1</li>
+          <li data-id="32">Topic 3-2</li>
+          <li data-id="33">Topic 3-3</li>
+        </ul>
+      </li>
+      <li data-id="4">Topic 4</li>
+      <li data-id="5">Topic 5</li>
+      <li data-id="6">Topic 6</li>
+      <li data-id="7">Topic 7</li>
+      <li data-id="8">Topic 8</li>
+    </ul>
+
+    <pre id="result-wrap"></pre>
+  </div>
 </div>
 
 <!-- Scripts -->
@@ -46,6 +53,8 @@
     window.ns = new NestedSort({
       actions: {
         onDrop: function (data) {
+          const resultWrap = document.getElementById('result-wrap')
+          resultWrap.innerHTML = JSON.stringify(data, null, '  ')
           console.log(`data ${usePropertyMapping ? 'with' : 'without'} property mapping`, data)
         }
       },

--- a/dev/server-rendered-list.html
+++ b/dev/server-rendered-list.html
@@ -39,7 +39,7 @@
       <li data-id="8">Topic 8</li>
     </ul>
 
-    <pre id="result-wrap"></pre>
+    <pre class="result-wrap"></pre>
   </div>
 </div>
 
@@ -53,7 +53,7 @@
     window.ns = new NestedSort({
       actions: {
         onDrop: function (data) {
-          const resultWrap = document.getElementById('result-wrap')
+          const resultWrap = document.querySelector('.result-wrap')
           resultWrap.innerHTML = JSON.stringify(data, null, '  ')
           console.log(`data ${usePropertyMapping ? 'with' : 'without'} property mapping`, data)
         }

--- a/dev/server-rendered-multiple-lists.html
+++ b/dev/server-rendered-multiple-lists.html
@@ -16,28 +16,38 @@
   <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse. Touch screens are not supported yet! 😐</p>
 
   <h2>List 1: Ordered List</h2>
-  <ol class="draggable">
-    <li data-id="1">Topic 1</li>
-    <li data-id="2">Topic 2</li>
-    <li data-id="3">Topic 3
-      <ol data-id="3">
-        <li data-id="4">Topic 4</li>
-      </ol>
-    </li>
-    <li data-id="5">Topic 5</li>
-  </ol>
+
+  <div class="sample-wrap">
+    <ol class="draggable" data-result-screen-id="1">
+      <li data-id="1">Topic 1</li>
+      <li data-id="2">Topic 2</li>
+      <li data-id="3">Topic 3
+        <ol data-id="3">
+          <li data-id="4">Topic 4</li>
+        </ol>
+      </li>
+      <li data-id="5">Topic 5</li>
+    </ol>
+
+    <pre class="result-wrap result-wrap-1"></pre>
+  </div>
 
   <h2>List 2: Unordered List</h2>
-  <ul class="draggable">
-    <li data-id="2">Topic 2
-      <ul data-id="2">
-        <li data-id="1">Topic 1</li>
-        <li data-id="3">Topic 3</li>
-      </ul>
-    </li>
-    <li data-id="4">Topic 4</li>
-    <li data-id="5">Topic 5</li>
-  </ul>
+
+  <div class="sample-wrap">
+    <ul class="draggable" data-result-screen-id="2">
+      <li data-id="2">Topic 2
+        <ul data-id="2">
+          <li data-id="1">Topic 1</li>
+          <li data-id="3">Topic 3</li>
+        </ul>
+      </li>
+      <li data-id="4">Topic 4</li>
+      <li data-id="5">Topic 5</li>
+    </ul>
+
+    <pre class="result-wrap result-wrap-2"></pre>
+  </div>
 </div>
 
 <!-- Scripts -->
@@ -48,6 +58,8 @@
       new NestedSort({
         actions: {
           onDrop: function (data) {
+            const resultWrap = document.querySelector(`.result-wrap-${list.dataset.resultScreenId}`)
+            resultWrap.innerHTML = JSON.stringify(data, null, '  ')
             console.log(data)
           }
         },

--- a/dev/styling-data-driven-list.html
+++ b/dev/styling-data-driven-list.html
@@ -23,8 +23,11 @@
   </p>
 
   <h2>Twitter Bootstrap [Data-driven List]</h2>
-  <div id="bootstrap"></div>
 
+  <div class="sample-wrap">
+    <div id="draggable"></div>
+    <pre class="result-wrap"></pre>
+  </div>
 </div>
 
 <!-- Scripts -->
@@ -45,11 +48,13 @@
     new NestedSort({
       actions: {
         onDrop: function (data) {
+          const resultWrap = document.querySelector('.result-wrap')
+          resultWrap.innerHTML = JSON.stringify(data, null, '  ')
           console.log(data)
         }
       },
       data: data,
-      el: '#bootstrap',
+      el: '#draggable',
       listClassNames: ['list-group'],
       listItemClassNames: ['list-group-item']
     })


### PR DESCRIPTION
So far we have been relying on `console` to check the `onDrop` data. Now we have a pre-formatted area which prints the newly ordered data:

![code sample improvement](https://github.com/hesamurai/nested-sort/assets/6011637/0d712266-069c-4bf5-9672-a70a00174f1e)
