### PR TITLE
docs: remove touch screen support related copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/nested-sort.svg)](https://badge.fury.io/js/nested-sort)
 [![](https://data.jsdelivr.com/v1/package/npm/nested-sort/badge)](https://www.jsdelivr.com/package/npm/nested-sort)
 
-Nested Sort is a vanilla JavaScript library, without any dependencies, which helps you to sort a nested list of items via drag and drop. Unfortunately, it does not support touch screens yet.
+Nested Sort is a vanilla JavaScript library, without any dependencies, which helps you to sort a nested list of items via drag and drop.
 
 ![](demo.gif)
 

--- a/dev/data-driven-list.html
+++ b/dev/data-driven-list.html
@@ -13,7 +13,7 @@
 <div class="container">
   <h1>A data-driven list</h1>
 
-  <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse. Touch screens are not supported yet! 😐</p>
+  <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse.</p>
 
   <div class="sample-wrap">
     <div id="draggable"></div>

--- a/dev/ordered-data-driven-list.html
+++ b/dev/ordered-data-driven-list.html
@@ -13,7 +13,7 @@
 <div class="container">
   <h1>An ordered data-driven list</h1>
 
-  <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse. Touch screens are not supported yet! 😐</p>
+  <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse.</p>
 
   <div class="sample-wrap">
     <div id="draggable"></div>

--- a/dev/server-rendered-multiple-lists.html
+++ b/dev/server-rendered-multiple-lists.html
@@ -13,7 +13,7 @@
 <div class="container">
   <h1>Multiple server-rendered lists</h1>
 
-  <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse. Touch screens are not supported yet! 😐</p>
+  <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse.</p>
 
   <h2>List 1: Ordered List</h2>
 

--- a/dev/styling-data-driven-list.html
+++ b/dev/styling-data-driven-list.html
@@ -14,7 +14,7 @@
 <div class="container">
   <h1>Styling</h1>
 
-  <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse. Touch screens are not supported yet! 😐</p>
+  <p>The main goal is to create a tree-like list of nested items. You should be able to achieve that by simply dragging and dropping the items using your mouse.</p>
 
   <p>
     You can use the listClassNames and listItemClassNames props on the Config object to assign custom class names to


### PR DESCRIPTION
Touch screens (especially iOS) now natively support drag and drop. Android supported this even before iOS.